### PR TITLE
fix: Update PostgreSQL version to supported 15.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -213,13 +213,91 @@ jobs:
         cd infrastructure
         echo "Destroying all AWS resources to prevent ongoing costs..."
         echo "This includes: VPC, ECS cluster, ECR repositories, RDS database, ALB, and all associated resources"
+        
+        # First attempt: Normal destroy
+        echo "Attempting normal terraform destroy..."
         terraform destroy -auto-approve \
                          -var="aws_access_key=${{ secrets.AWS_ACCESS_KEY_ID }}" \
                          -var="aws_secret_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}" \
                          -var="aws_account_id=${{ secrets.AWS_ACCOUNT_ID }}" \
                          -var="database_password=gym-admin-pass" \
-                         -var="database_username=gym_admin"
-        echo "All AWS resources have been successfully destroyed"
+                         -var="database_username=gym_admin" || true
+        
+        # Second attempt: Force destroy with refresh
+        echo "Attempting force destroy with refresh..."
+        terraform refresh \
+                         -var="aws_access_key=${{ secrets.AWS_ACCESS_KEY_ID }}" \
+                         -var="aws_secret_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}" \
+                         -var="aws_account_id=${{ secrets.AWS_ACCOUNT_ID }}" \
+                         -var="database_password=gym-admin-pass" \
+                         -var="database_username=gym_admin" || true
+        
+        terraform destroy -auto-approve \
+                         -var="aws_access_key=${{ secrets.AWS_ACCESS_KEY_ID }}" \
+                         -var="aws_secret_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}" \
+                         -var="aws_account_id=${{ secrets.AWS_ACCOUNT_ID }}" \
+                         -var="database_password=gym-admin-pass" \
+                         -var="database_username=gym_admin" || true
+        
+        # Third attempt: Target specific resources that might be stuck
+        echo "Attempting targeted destroy for remaining resources..."
+        terraform destroy -auto-approve \
+                         -target=aws_ecs_service.gym_platform_backend_service \
+                         -target=aws_ecs_service.gym_platform_frontend_service \
+                         -target=aws_lb.gym_platform_alb \
+                         -target=aws_db_instance.gym_platform_db \
+                         -var="aws_access_key=${{ secrets.AWS_ACCESS_KEY_ID }}" \
+                         -var="aws_secret_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}" \
+                         -var="aws_account_id=${{ secrets.AWS_ACCOUNT_ID }}" \
+                         -var="database_password=gym-admin-pass" \
+                         -var="database_username=gym_admin" || true
+        
+        # Final cleanup attempt
+        echo "Final cleanup attempt..."
+        terraform destroy -auto-approve \
+                         -var="aws_access_key=${{ secrets.AWS_ACCESS_KEY_ID }}" \
+                         -var="aws_secret_key=${{ secrets.AWS_SECRET_ACCESS_KEY }}" \
+                         -var="aws_account_id=${{ secrets.AWS_ACCOUNT_ID }}" \
+                         -var="database_password=gym-admin-pass" \
+                         -var="database_username=gym_admin" || true
+        
+        echo "Cleanup process completed. Check above for any remaining resources."
+
+    - name: Manual Cleanup Fallback
+      run: |
+        echo "Performing manual cleanup of any remaining resources..."
+        
+        # Clean up ECS services
+        echo "Cleaning up ECS services..."
+        aws ecs list-services --cluster gym-platform-cluster --query 'serviceArns[]' --output text | \
+        xargs -I {} aws ecs update-service --cluster gym-platform-cluster --service {} --desired-count 0 || true
+        
+        aws ecs list-services --cluster gym-platform-cluster --query 'serviceArns[]' --output text | \
+        xargs -I {} aws ecs delete-service --cluster gym-platform-cluster --service {} || true
+        
+        # Clean up ECS cluster
+        echo "Cleaning up ECS cluster..."
+        aws ecs delete-cluster --cluster gym-platform-cluster || true
+        
+        # Clean up ECR repositories
+        echo "Cleaning up ECR repositories..."
+        aws ecr delete-repository --repository-name gym-platform-app --force || true
+        aws ecr delete-repository --repository-name gym-platform-frontend --force || true
+        
+        # Clean up RDS instances
+        echo "Cleaning up RDS instances..."
+        aws rds delete-db-instance --db-instance-identifier gym-platform-db --skip-final-snapshot || true
+        
+        # Clean up Load Balancers
+        echo "Cleaning up Load Balancers..."
+        aws elbv2 describe-load-balancers --query 'LoadBalancers[?contains(LoadBalancerName, `gym-platform`)].LoadBalancerArn' --output text | \
+        xargs -I {} aws elbv2 delete-load-balancer --load-balancer-arn {} || true
+        
+        # Clean up S3 buckets
+        echo "Cleaning up S3 buckets..."
+        aws s3 ls | grep gym-platform | awk '{print $3}' | xargs -I {} aws s3 rb s3://{} --force || true
+        
+        echo "Manual cleanup completed."
 
     - name: Workflow Summary
       run: |

--- a/infrastructure/.gitignore
+++ b/infrastructure/.gitignore
@@ -1,0 +1,31 @@
+# Terraform files
+*.tfstate
+*.tfstate.*
+*.tfvars
+.terraform/
+.terraform.lock.hcl
+terraform.tfstate.lock.info
+
+# Crash log files
+crash.log
+crash.*.log
+
+# Exclude all .tfvars files, which are likely to contain sensitive data
+*.tfvars
+*.tfvars.json
+
+# Ignore override files as they are usually used to override resources locally
+override.tf
+override.tf.json
+*_override.tf
+*_override.tf.json
+
+# Include override files you do wish to add to version control using negated pattern
+# !example_override.tf
+
+# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
+*tfplan*
+
+# Ignore CLI configuration files
+.terraformrc
+terraform.rc

--- a/infrastructure/.terraform.lock.hcl
+++ b/infrastructure/.terraform.lock.hcl
@@ -1,0 +1,25 @@
+# This file is maintained automatically by "terraform init".
+# Manual edits may be lost in future updates.
+
+provider "registry.terraform.io/hashicorp/aws" {
+  version     = "5.100.0"
+  constraints = "~> 5.0"
+  hashes = [
+    "h1:Ijt7pOlB7Tr7maGQIqtsLFbl7pSMIj06TVdkoSBcYOw=",
+    "zh:054b8dd49f0549c9a7cc27d159e45327b7b65cf404da5e5a20da154b90b8a644",
+    "zh:0b97bf8d5e03d15d83cc40b0530a1f84b459354939ba6f135a0086c20ebbe6b2",
+    "zh:1589a2266af699cbd5d80737a0fe02e54ec9cf2ca54e7e00ac51c7359056f274",
+    "zh:6330766f1d85f01ae6ea90d1b214b8b74cc8c1badc4696b165b36ddd4cc15f7b",
+    "zh:7c8c2e30d8e55291b86fcb64bdf6c25489d538688545eb48fd74ad622e5d3862",
+    "zh:99b1003bd9bd32ee323544da897148f46a527f622dc3971af63ea3e251596342",
+    "zh:9b12af85486a96aedd8d7984b0ff811a4b42e3d88dad1a3fb4c0b580d04fa425",
+    "zh:9f8b909d3ec50ade83c8062290378b1ec553edef6a447c56dadc01a99f4eaa93",
+    "zh:aaef921ff9aabaf8b1869a86d692ebd24fbd4e12c21205034bb679b9caf883a2",
+    "zh:ac882313207aba00dd5a76dbd572a0ddc818bb9cbf5c9d61b28fe30efaec951e",
+    "zh:bb64e8aff37becab373a1a0cc1080990785304141af42ed6aa3dd4913b000421",
+    "zh:dfe495f6621df5540d9c92ad40b8067376350b005c637ea6efac5dc15028add4",
+    "zh:f0ddf0eaf052766cfe09dea8200a946519f653c384ab4336e2a4a64fdd6310e9",
+    "zh:f1b7e684f4c7ae1eed272b6de7d2049bb87a0275cb04dbb7cda6636f600699c9",
+    "zh:ff461571e3f233699bf690db319dfe46aec75e58726636a0d97dd9ac6e32fb70",
+  ]
+}

--- a/infrastructure/.terraform.tfstate.lock.info
+++ b/infrastructure/.terraform.tfstate.lock.info
@@ -1,0 +1,1 @@
+{"ID":"bd40f367-6b6e-9b65-783a-7e9b5bef8fb9","Operation":"OperationTypePlan","Info":"","Who":"ryosukeyano@Ryosukes-MacBook-Pro.local","Version":"1.5.7","Created":"2025-09-06T00:39:11.127396Z","Path":"terraform.tfstate"}

--- a/infrastructure/alb.tf
+++ b/infrastructure/alb.tf
@@ -11,12 +11,6 @@ resource "aws_lb" "gym_platform_alb" {
 
   enable_deletion_protection = false
 
-  # Disable access logs for now to avoid S3 permission issues
-  # access_logs {
-  #   bucket  = aws_s3_bucket.gym_platform_alb_logs.bucket
-  #   enabled = true
-  # }
-
   tags = {
     Name        = "${var.r_prefix}-alb"
     Environment = var.environment

--- a/infrastructure/rds.tf
+++ b/infrastructure/rds.tf
@@ -15,7 +15,7 @@ resource "aws_db_subnet_group" "gym_platform_db_subnet_group" {
 resource "aws_db_instance" "gym_platform_db" {
   identifier     = "${var.r_prefix}-db"
   engine         = "postgres"
-  engine_version = "15.3"
+  engine_version = "15.13"
   instance_class = "db.t3.micro"
 
   allocated_storage     = 20


### PR DESCRIPTION
- Change from PostgreSQL 15.3 to 15.13 (latest supported version)
- Resolves RDS instance creation error
- Ensures compatibility with AWS RDS in ap-northeast-1 region
- Add multi-stage terraform destroy with error handling
- Include targeted destroy for specific resources  
- Add manual AWS CLI cleanup as fallback
- Ensure all ECS, ECR, RDS, ALB, and S3 resources are removed
- Add .gitignore for Terraform state files
- Prevent any remaining resources from causing costs